### PR TITLE
remove Thrift2 from TODO list

### DIFF
--- a/TODO.rst
+++ b/TODO.rst
@@ -12,7 +12,3 @@ future, depending on time, demand, and technical possibilities.
   Thrift layer. Maybe wrap the errors in a HappyBase.Error?
 
 * Automatic retries for failed operations (but only those that can be retried)
-
-* Port HappyBase over to the (still experimental) HBase Thrift2 API when it
-  becomes mainstream, and expose more of the underlying features nicely in the
-  HappyBase API.


### PR DESCRIPTION
looks like it's already done here: https://github.com/python-happybase/happybase/pull/222 so the documentation is not updated (this bullet was created 9 years ago and the thrift2 support was added 2 years ago).