### PR TITLE
docs: fix simple typo, underyling -> underlying

### DIFF
--- a/happybase/connection.py
+++ b/happybase/connection.py
@@ -176,7 +176,7 @@ class Connection(object):
         self.transport.open()
 
     def close(self):
-        """Close the underyling transport to the HBase instance.
+        """Close the underlying transport to the HBase instance.
 
         This method closes the underlying Thrift transport (TCP connection).
         """


### PR DESCRIPTION
There is a small typo in happybase/connection.py.

Should read `underlying` rather than `underyling`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md