### PR TITLE
Use importlib-resources package instead of pkg_resources

### DIFF
--- a/happybase/__init__.py
+++ b/happybase/__init__.py
@@ -3,10 +3,11 @@ HappyBase, a developer-friendly Python library to interact with Apache
 HBase.
 """
 
-import pkg_resources as _pkg_resources
+import importlib_resources as _importlib_resources
 import thriftpy2 as _thriftpy
+
 _thriftpy.load(
-    _pkg_resources.resource_filename('happybase', 'Hbase.thrift'),
+    str(_importlib_resources.files('happybase') / 'Hbase.thrift'),
     'Hbase_thrift')
 
 from ._version import __version__  # noqa

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 six
 thriftpy2>=0.4
+importlib-resources


### PR DESCRIPTION
Because: 
- pkg_resources is deprecated in Python 3.12, and
- importlib-resources is backwards compatible.